### PR TITLE
Add race countdown timer to homepage

### DIFF
--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -1,3 +1,6 @@
+// cache the next race event so we only need to look it up once
+var nextRaceEvent = null;
+
 function displayHeroContent() {
   var blockToShow;
   var heroBlocks = $(".hero-announcement-content-block");
@@ -10,6 +13,11 @@ function displayHeroContent() {
   }
 
   if (blockToShow) {
+    // if there's an upcoming race event, 
+    // we need to populate some extra dynamic content
+    if (nextRaceEvent) {
+      populateRaceEventContent(blockToShow);
+    }
     heroBlocks.not(blockToShow).remove();
     $(blockToShow).addClass("the-chosen-one");
   }
@@ -19,6 +27,8 @@ function shouldShowBlock(block) {
   switch ($(block).attr("id")) {
     case "latest-announcement":
       return shouldShowLatestAnnouncement(block)
+    case "next-race-event":
+      return shouldShowNextRaceEvent(block);
     case "default":
       return true;
     default:
@@ -26,8 +36,8 @@ function shouldShowBlock(block) {
   }
 }
 
-function shouldShowLatestAnnouncement(latestAnnouncement) {
-  var dateData = $(latestAnnouncement).data("date");
+function shouldShowLatestAnnouncement(latestAnnouncementBlock) {
+  var dateData = $(latestAnnouncementBlock).data("date");
 
   if (!dateData) {
     return false;
@@ -36,7 +46,124 @@ function shouldShowLatestAnnouncement(latestAnnouncement) {
   var announcementDate = new Date(dateData)
   var daysSinceAnnouncement = Math.floor(((new Date() - announcementDate) / 1000) / (60 * 60 *24));
 
-  return daysSinceAnnouncement <= 10;
+  return daysSinceAnnouncement <= 7;
+}
+
+function shouldShowNextRaceEvent(raceScheduleBlock) {
+  var scheduleData = $(raceScheduleBlock).data("schedule");
+
+  if (!scheduleData) {
+    return false;
+  }
+
+  return !!getNextRaceEvent(scheduleData);
+}
+
+// looks through the schedule and finds the next
+// race event in the list (based on the current date)
+function getNextRaceEvent(schedule) {
+  if (!nextRaceEvent) {
+    var now  = new Date();
+    var currentMonth = now.getMonth();
+    var currentDay = now.getDate();
+    var scheduleIndex = 0;
+    
+    while (!nextRaceEvent && scheduleIndex < schedule.length) {
+      var currentEvent = schedule[scheduleIndex];
+      var { month, day } = extractRaceEventMonthAndDay(currentEvent);
+  
+      // event is in a month that's in the past OR
+      // event is this month, but is on a day that's in the past
+      if (month < currentMonth || (month === currentMonth && day < currentDay)) {
+        scheduleIndex++;
+        continue;
+      }
+  
+      // otherwise, this is the next event!
+      nextRaceEvent = currentEvent;
+    }
+  }
+
+  return nextRaceEvent;
+}
+
+// if there is an upcoming/current race event,
+// we'll either show a countdown clock or let folx know it's race day
+function populateRaceEventContent(block) {
+  var { month, day } = extractRaceEventMonthAndDay(nextRaceEvent);
+  // BUT Javascript dates are NOT ZERO-INDEXED when you're trying to make a date (╯°□°)╯︵ ┻━┻
+  var nextRaceEventDate = new Date(`${month + 1} ${day} ${new Date().getFullYear()}`);
+
+  var textContainer = $(block).children(".hero-announcement-text");
+  if (new Date().getDate() === nextRaceEventDate.getDate()) {
+    textContainer.append($("<h1>").text("It's Race Day!"));
+  } else {
+    var eventTime = nextRaceEventDate.getTime();
+    var countdownContainer = $("<h1>").attr("id", "race-countdown-clock").text("");
+
+    textContainer.append($("<h1>").text("Next Race Round"));
+    textContainer.append($("<h2>").text(`${nextRaceEvent.date} at ${nextRaceEvent.location}`));
+    textContainer.append(countdownContainer);
+
+    // populate the countdown clock immediately, 
+    // then start updating every second (otherwise it is momentarily invisible)
+    calculateNextCountdownTime(eventTime, countdownContainer);
+    setInterval(function() {
+      calculateNextCountdownTime(eventTime, countdownContainer);
+    }, 1000);
+  }
+}
+
+// https://www.w3schools.com/howto/howto_js_countdown.asp
+function calculateNextCountdownTime(eventTime, countdownContainer) {
+  var nowTime = new Date().getTime();
+  var distance = eventTime - nowTime;
+
+  // time calculations for days, hours, minutes and seconds
+  var days = formatCountdownNumber(Math.floor(distance / (1000 * 60 * 60 * 24)));
+  var hours = formatCountdownNumber(Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
+  var minutes = formatCountdownNumber(Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60)));
+  var seconds = formatCountdownNumber(Math.floor((distance % (1000 * 60)) / 1000));
+
+  var timeString = `${days}d ${hours}h ${minutes}m ${seconds}s`
+  countdownContainer.text(timeString);
+}
+
+// event data format: "May 17-18"
+function extractRaceEventMonthAndDay(raceEvent) {
+  var eventDateParts = raceEvent.date.split(" ");
+  return { 
+    month: getMonthNumber(eventDateParts[0]), 
+    day: parseInt(eventDateParts[1].split("-")[0]), 
+  };
+}
+
+// pads any single-digit numbers with a leading 0 
+// so they don't constantly change the width of the timer
+function formatCountdownNumber(countdownNumber) {
+  return countdownNumber.toString().padStart(2, '0');
+}
+
+// AnNa WhY nOt JuSt UsE a lIbRaRy?
+// it's overkill, that's why
+// also, months in Javascript are zero-indexed, so
+const MONTH_NAMES = [ 
+  "January", 
+  "February", 
+  "March", 
+  "April", 
+  "May", 
+  "June", 
+  "July", 
+  "August", 
+  "September", 
+  "October", 
+  "November", 
+  "December",
+];
+
+function getMonthNumber(name) {
+  return MONTH_NAMES.indexOf(name);
 }
 
 $(document).ready(function() {

--- a/layouts/partials/hero-announcement-content.html
+++ b/layouts/partials/hero-announcement-content.html
@@ -1,11 +1,16 @@
-
+{{ $whatYearIsIt := string time.Now.Year }}
 {{ $latestNews := (where site.RegularPages.ByDate "Section" "news" | last 1) }}
-{{/* Add: last race results, countdown to next race */}}
+{{ $currentSchedule := jsonify (index site.Data.schedule $whatYearIsIt) }}
+{{/* Add: last race results */}}
 
 <div class="hero-announcement-content">
-  {{/* Only ONE of these will remain, and the fancy javascript will decide which one */}}
+  {{/* Only ONE of these will remain; the fancy javascript will decide which one */}} 
   {{ range $latestNews }}
-    <div id="latest-announcement" class="hero-announcement-content-block" data-date="{{ .Date }}">
+    <div
+      id="latest-announcement"
+      class="hero-announcement-content-block"
+      data-date="{{ .Date }}"
+    >
       <div class="hero-announcement-text">
         <h1>{{ .Title }}</h1>
         <h3>{{ .Description }}</h3>
@@ -14,9 +19,17 @@
     </div>
   {{ end }}
 
-  <div id="default" class="hero-announcement-content-block" >
+  <div
+    id="next-race-event"
+    class="hero-announcement-content-block"
+    data-schedule="{{ $currentSchedule }}"
+  >
+    {{/* Yes, it's an empty div! It'll be populated via Javascript */}}
+    <div class="hero-announcement-text"></div>
+  </div>
+
+  <div id="default" class="hero-announcement-content-block">
     <div class="hero-announcement-text"><h1>Welcome to WMRRA!</h1></div>
     <a class="hero-announcement-button" href="">Learn More</a>
   </div>
 </div>
-


### PR DESCRIPTION
Does what it says on the tin. Adds a fancy countdown timer for the next race round that will show up in the homepage hero when there is a next race round and when there's not a recent (last 7 days) news post.

It could be styled better. Maybe someday.

<img width="1023" alt="Screen Shot 2021-03-17 at 10 40 06 PM" src="https://user-images.githubusercontent.com/906840/111578714-e7815880-8771-11eb-8988-5b2bfa9278e3.png">