### PR TITLE
Responsive header images

### DIFF
--- a/assets/sass/custom.scss
+++ b/assets/sass/custom.scss
@@ -284,6 +284,39 @@ $xxxlarge-screen-breakpoint: 120em; // big
   }
 }
 
+// TODO: yet another partial
+.new-racer-header {
+  @include header-text;
+  margin: 4rem 0 3rem;
+
+  .logo {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 6rem;
+    margin-top: -1rem;
+
+    @include media-min($small-screen-breakpoint) {
+      max-height: 7rem;
+      margin-left: 0.5rem;
+    }
+  }
+    
+  h1 {
+    margin: 0;
+    font-size: 4rem;
+    text-transform: uppercase;
+
+    @include media-min($small-screen-breakpoint) {
+      font-size: 5rem;
+    }
+
+    @include media-max($mobile-breakpoint) {
+      margin-bottom: 1rem;
+    }
+  }
+}
+
 // TODO: another partial
 .become-a-supporter-header {
   margin-bottom: 2rem;

--- a/assets/sass/partials/_homepage.scss
+++ b/assets/sass/partials/_homepage.scss
@@ -87,14 +87,7 @@
 }
 
 .home-content-section-header {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-
-  @include media-max($mobile-breakpoint) {
-    flex-direction: column;
-  }
+  @include header-text;
 
   .logo {
     width: auto;

--- a/assets/sass/partials/_mixins.scss
+++ b/assets/sass/partials/_mixins.scss
@@ -157,3 +157,14 @@
   font-size: 3rem;
   color: $level-color;
 }
+
+@mixin header-text { 
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+
+  @include media-max($mobile-breakpoint) {
+    flex-direction: column;
+  }
+}

--- a/content/race/new-racer-information.md
+++ b/content/race/new-racer-information.md
@@ -1,11 +1,12 @@
-![](/images/Novice-Racer.jpg)
+---
+title   : "New Racer Information"
+date    : 2021-02-01T20:45:00-8:00
+draft   : false
+description: "New Racer Information"
+headerImage: "/images/Novice-Racer.jpg"
+---
 
-<div class="home-content-section-header">
-    <h1>You are</h1>
-    <img class="logo" alt="WMRRA - Washington Motorcycle Road Racing Association" src="/images/WMRRA-logo.jpg">
-    </br>
-    </br>
-  </div>
+{{< incpartial "new-racer-header.html" >}}
 
 Congratulations on taking the first step on your journey to being a motorcycle
 road racer. This is a journey you'll remember forever.

--- a/content/race/rulebook.md
+++ b/content/race/rulebook.md
@@ -3,10 +3,9 @@ title   : "Rulebook"
 date    : 2021-02-01T20:45:00-8:00
 draft   : false
 description: "Rulebook"
+showTitle: true
+headerImage: "/images/Racer-Responsibility.jpg"
 ---
-# Rulebook
-
-![](/images/Racer-Responsibility.jpg)
 
 As a racer, it’s your responsibility to know the rules, read the rule book!
 

--- a/content/volunteer/index.md
+++ b/content/volunteer/index.md
@@ -3,9 +3,8 @@ title   : "Volunteer"
 date    : 2021-01-31T14:45:00-8:00
 draft   : false
 description: "Volunteer With WMRRA"
+headerImage: "/images/Volunteers-2.jpg"
 ---
-
-![](/images/Volunteers-2.jpg)
 
 # Come join us!
 Love watching motorcycle racing? Want to see what happens behind the scenes? Join us for the best seat in the house!

--- a/layouts/partials/new-racer-header.html
+++ b/layouts/partials/new-racer-header.html
@@ -1,0 +1,4 @@
+<div class="new-racer-header">
+  <h1>You are</h1>
+  <img class="logo" alt="WMRRA - Washington Motorcycle Road Racing Association" src="/images/WMRRA-logo.jpg">
+</div>

--- a/themes/wmrra-com-theme/assets/sass/main.scss
+++ b/themes/wmrra-com-theme/assets/sass/main.scss
@@ -84,7 +84,25 @@ p {
 @import "themes/wmrra-com-theme/assets/sass/partials/hero";
 @import "themes/wmrra-com-theme/assets/sass/partials/footer";
 
-// TODO: make a partial for this
+// TODO: make a partial for this content
+.header-image-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 10rem;
+  margin-bottom: 2rem;
+  overflow: hidden;
+
+  img {
+    height: 10rem;
+
+    @include media-min($medium-screen-breakpoint) {
+      max-width: 100%;
+      height: auto;
+    }
+  }
+}
+
 .news-summary {
   margin: 1rem;
   border: 0.1rem solid #333;

--- a/themes/wmrra-com-theme/layouts/_default/single.html
+++ b/themes/wmrra-com-theme/layouts/_default/single.html
@@ -1,7 +1,15 @@
 {{ define "main" }}
+  <div class="content-wrapper">
+    {{ if .Params.showTitle }}
+      <h1>{{ .Params.title }}</h1>  
+    {{ end }}
 
-<div class="content-wrapper">
+    {{ if .Params.headerImage}}
+      <div class="header-image-wrapper">
+        <img src="{{ .Params.headerImage }}" />
+      </div>
+    {{ end }}
+  
     <div>{{ .Content }}</div>
-</div>
-
+  </div>
 {{ end }}


### PR DESCRIPTION
Previously, header images would not resize with the page, causing massive sidescroll on small screens. 
These changes make the header images responsive. It also pushes them into the `single` page template and moves their definition to front matter in markdown pages. This makes them easier to include and style.

An additional, semi-related change: moving the fancy "new racer" header into a partial and giving its own styles. This helps it fit and flow better with the page and makes it less susceptible to "accidental" editing by separating it from the page's content.

<img width="396" alt="Screen Shot 2021-04-04 at 1 20 32 PM" src="https://user-images.githubusercontent.com/906840/113520634-3ccab180-9549-11eb-855e-7130f595baff.png">
