### PR TITLE
Use a fuller date comparison for deciding if it's race day

### DIFF
--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -110,9 +110,10 @@ function populateRaceEventContent(block) {
   // BUT Javascript dates are NOT ZERO-INDEXED when you're trying to make a date (╯°□°)╯︵ ┻━┻
   // also, if you don't put the slashes in the date, Safari cries about it
   var nextRaceEventDate = new Date(`${month + 1}/${day}/${new Date().getFullYear()}`);
+  console.log(nextRaceEventDate)
 
   var textContainer = $(block).children(".hero-announcement-text");
-  if (new Date().getDate() === nextRaceEventDate.getDate()) {
+  if (areSameDate(new Date(), nextRaceEventDate)) {
     textContainer.append($("<h1>").text("It's Race Day!"));
   } else {
     var eventTime = nextRaceEventDate.getTime();
@@ -183,6 +184,16 @@ function extractRaceEventMonthAndDay(raceEvent) {
     month: getMonthNumber(eventDateParts[0]), 
     day: parseInt(eventDateParts[1].split("-")[0]), 
   };
+}
+
+// Returns true if year, month, and day of both of the
+// passed dates are the same
+function areSameDate(date1, date2) {
+  return (
+    date1.getYear() === date2.getYear() 
+    && date1.getMonth() === date2.getMonth() 
+    && date1.getDate() === date2.getDate()
+  );
 }
 
 // pads any single-digit numbers with a leading 0 

--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -110,7 +110,6 @@ function populateRaceEventContent(block) {
   // BUT Javascript dates are NOT ZERO-INDEXED when you're trying to make a date (╯°□°)╯︵ ┻━┻
   // also, if you don't put the slashes in the date, Safari cries about it
   var nextRaceEventDate = new Date(`${month + 1}/${day}/${new Date().getFullYear()}`);
-  console.log(nextRaceEventDate)
 
   var textContainer = $(block).children(".hero-announcement-text");
   if (areSameDate(new Date(), nextRaceEventDate)) {


### PR DESCRIPTION
Fixes a bug where we were incorrectly proclaiming it "race day!" This was because I used `getDate()` to make the comparison, which, despite its name, just gets the "day" part of the date - so `new Date(Apr 8, 2021).getDate() === new Date(May 8, 2021)` would be true.

Added a fuller comparison method that will compare all relevant parts of the date so we don't get anyone's hopes up about it being race day.

Since race day takes place over a whole weekend, I'll need to actually do some kind of range comparison, but for now, this'll do.  I'll open an issue for the other thing.