### PR TITLE
Improve race day hero content

### DIFF
--- a/assets/sass/partials/_homepage.scss
+++ b/assets/sass/partials/_homepage.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   justify-content: center;
   height: 100%;
+  width: 100%;
   opacity: 0;
 
   &.the-chosen-one {
@@ -58,6 +59,35 @@
   .countdown-label {
     font-size: 1.6rem;
     font-weight: 500;
+  }
+}
+
+.race-day-button-wrapper {
+  @include flex-column-centered;
+
+  width: 100%;
+  max-width: 45rem;
+  margin: 0 auto;
+
+  @include media-min($large-screen-breakpoint) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-around;
+  }
+
+  .hero-announcement-button {
+    width: 20rem;
+    margin-bottom: 1.5rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    @include media-min($large-screen-breakpoint) {
+      &:last-child {
+        margin-bottom: 1.5rem;
+      }
+    }
   }
 }
 

--- a/layouts/partials/hero-announcement-content.html
+++ b/layouts/partials/hero-announcement-content.html
@@ -1,7 +1,7 @@
-{{ $whatYearIsIt := string time.Now.Year }}
+{{ $whatYearIsIt := string time.Now.Year }} 
 {{ $latestNews := (where site.RegularPages.ByDate "Section" "news" | last 1) }}
-{{ $currentSchedule := jsonify (index site.Data.schedule $whatYearIsIt) }}
-{{/* Add: last race results */}}
+{{ $currentSchedule := jsonify (index site.Data.schedule $whatYearIsIt) }} 
+{{/* To add: last race results */}}
 
 <div class="hero-announcement-content">
   {{/* Only ONE of these will remain; the fancy javascript will decide which one */}} 
@@ -24,8 +24,19 @@
     class="hero-announcement-content-block"
     data-schedule="{{ $currentSchedule }}"
   >
-    {{/* Yes, it's an empty div! It'll be populated via Javascript */}}
-    <div class="hero-announcement-text"></div>
+    <div class="hero-announcement-text">
+      <h1>It's Race Day!</h1>
+    </div>
+
+    <div class="race-day-button-wrapper">
+      <a
+        class="hero-announcement-button"
+        href="https://racehero.io/orgs/wmrra-official"
+        target="_blank"
+      >
+        Live Timing
+      </a>
+    </div>
   </div>
 
   <div id="default" class="hero-announcement-content-block">

--- a/themes/wmrra-com-theme/assets/sass/partials/_hero.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_hero.scss
@@ -76,10 +76,19 @@
 }
 
 .hero-announcement-text {
-  margin-bottom: 2rem;
+  @include flex-column-centered;
+  margin: 0 auto 2rem;
+
+  h1,
+  h2 {
+    line-height: 4rem;
+  }
 }
 
 .hero-announcement-button {
+  @include link-overrides($white);
+
+  display: inline-block;
   padding: 1rem;
   border: 0.2rem solid $white;
   color: $white;
@@ -87,10 +96,6 @@
   box-shadow: $default-box-shadow;
 
   &:hover {
-    margin-top: -0.2rem;
-    border-width: 0.3rem;
-    color: $white;
-    text-decoration: none;
-    font-weight: bold;
+    transform: scale(1.1);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/wmrra/wmrra-com/issues/45

* Ensures the "It's Race Day!" hero content will display for all event days (not just the first)
* Adds round and location text to race day hero content
* Adds some quick link buttons for race day resources (live timing, circuit info)
* Fixes a style bug where the hero buttons could jitter the content on hover
* Fixes a style bug where the hero buttons had incorrect "visited" styles

<img width="1130" alt="Screen Shot 2021-04-08 at 9 39 33 PM" src="https://user-images.githubusercontent.com/906840/114129784-1e034c80-98b4-11eb-8f45-9a9cd96c01bf.png">
