### PR TITLE
Fix hero content styling

### DIFF
--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -116,7 +116,7 @@ function populateRaceEventContent(block) {
   var raceEventDays = extractRaceEventDates(nextRaceEvent);
   var textContainer = $(block).children(".hero-announcement-text");
 
-  if (raceEventDays.some(eventDate => areSameDate(new Date(), eventDate))) {
+  if (raceEventDays.some(eventDate => areSameDate(new Date("05/08/2021"), eventDate))) {
     textContainer.append($("<h2>").text(`Round ${nextRaceEvent.round} at ${nextRaceEvent.location}`))
     var circuitInfoButton = $("<a>").addClass("hero-announcement-button").attr("href", nextRaceEvent.locationLink).attr("target", "_blank").text("Circuit Info");
     textContainer.siblings(".race-day-button-wrapper").append(circuitInfoButton);

--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -116,7 +116,7 @@ function populateRaceEventContent(block) {
   var raceEventDays = extractRaceEventDates(nextRaceEvent);
   var textContainer = $(block).children(".hero-announcement-text");
 
-  if (raceEventDays.some(eventDate => areSameDate(new Date("05/08/2021"), eventDate))) {
+  if (raceEventDays.some(eventDate => areSameDate(new Date(), eventDate))) {
     textContainer.append($("<h2>").text(`Round ${nextRaceEvent.round} at ${nextRaceEvent.location}`))
     var circuitInfoButton = $("<a>").addClass("hero-announcement-button").attr("href", nextRaceEvent.locationLink).attr("target", "_blank").text("Circuit Info");
     textContainer.siblings(".race-day-button-wrapper").append(circuitInfoButton);

--- a/layouts/partials/hero-announcement-content.html
+++ b/layouts/partials/hero-announcement-content.html
@@ -15,7 +15,9 @@
         <h1>{{ .Title }}</h1>
         <h3>{{ .Description }}</h3>
       </div>
-      <a class="hero-announcement-button" href="{{ .Permalink }}">Read More</a>
+      <div class="hero-announcement-button-wrapper">
+        <a class="hero-announcement-button" href="{{ .Permalink }}">Read More</a>
+      </div>
     </div>
   {{ end }}
 

--- a/themes/wmrra-com-theme/assets/sass/partials/_hero.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_hero.scss
@@ -79,16 +79,27 @@
   @include flex-column-centered;
   margin: 0 auto 2rem;
 
-  h1,
+  h1 {
+    max-width: 90%;
+    line-height: 5rem;
+  }
+
   h2 {
     line-height: 4rem;
   }
+}
+
+.hero-announcement-button-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .hero-announcement-button {
   @include link-overrides($white);
 
   display: inline-block;
+  min-width: 20rem;
   padding: 1rem;
   border: 0.2rem solid $white;
   color: $white;


### PR DESCRIPTION
Fixes https://github.com/wmrra/wmrra-com/issues/47

I made some changes to the hero content styles to accommodate the new "race day" content, not realizing that it would have a negative impact on the "news/announcement" content.

These changes reign in the button and content width for 1000% more professionalism.

<img width="726" alt="Screen Shot 2021-04-09 at 7 05 29 PM" src="https://user-images.githubusercontent.com/906840/114254881-f6b98780-9966-11eb-8f34-69ac00aba127.png">
