### PR TITLE
Add tooty bike icon to schedule

### DIFF
--- a/content/race/events/2021-round-1.md
+++ b/content/race/events/2021-round-1.md
@@ -8,7 +8,7 @@ useEventLayout: true
 
 [Click Here to Register](http://msreg.com/WMRRAR1RIDGE2021)
 
-# Saturday (May 8)
+# Saturday
 
 | Time     | Session | Qualifying | Description                                                                     |
 | -------- | ------- | ---------- | ------------------------------------------------------------------------------- |
@@ -48,7 +48,7 @@ useEventLayout: true
 |          |         |            | Awards approx. 1 hour after finish                                              |
 
 
-# Sunday (May 9)
+# Sunday
 
 | Time     | Session | Qualifying | Description                                                                     |
 | -------- | ------- | ---------- | ------------------------------------------------------------------------------- |

--- a/themes/wmrra-com-theme/assets/sass/main.scss
+++ b/themes/wmrra-com-theme/assets/sass/main.scss
@@ -115,12 +115,23 @@ p {
     margin-top: 4rem;
     position: relative;
 
-    &::after {
-      content: "";
-      flex: 1;
-      height: 0.3rem;
-      margin-left: 1rem;
-      background-color: #b1041d;
+    @include media-min($small-screen-breakpoint) {
+      &::before {
+        @include pseudo-icon("\f21c");
+        position: absolute;
+        right: 0;
+        padding-left: 1rem;
+        background-color: $white;
+        color: $wmmra-dark-red;
+      }
+      
+      &::after {
+        content: "";
+        flex: 1;
+        height: 0.3rem;
+        margin-left: 1rem;
+        background-color: #b1041d;
+      }
     }
   }
 


### PR DESCRIPTION
A very important addition to the event schedule page.

<img width="625" alt="Screen Shot 2021-04-30 at 8 58 28 PM" src="https://user-images.githubusercontent.com/906840/116770246-ee4ced80-a9f6-11eb-8b2a-47bb3476fc47.png">
