### PR TITLE
Add event schedule button to homepage on race day

### DIFF
--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -116,9 +116,12 @@ function populateRaceEventContent(block) {
   var raceEventDays = extractRaceEventDates(nextRaceEvent);
   var textContainer = $(block).children(".hero-announcement-text");
 
-  if (raceEventDays.some(eventDate => areSameDate(new Date(), eventDate))) {
+  if (raceEventDays.some(eventDate => areSameDate(new Date("05-08-2021"), eventDate))) {
     textContainer.append($("<h2>").text(`Round ${nextRaceEvent.round} at ${nextRaceEvent.location}`))
     var circuitInfoButton = $("<a>").addClass("hero-announcement-button").attr("href", nextRaceEvent.locationLink).attr("target", "_blank").text("Circuit Info");
+    var scheduleUrl = `${window.location.origin}/race/events/${raceEventDays[0].getFullYear()}-round-${nextRaceEvent.round}`;
+    var scheduleButton = $("<a>").addClass("hero-announcement-button").attr("href", scheduleUrl).attr("target", "_blank").text("Event Schedule");
+    textContainer.siblings(".race-day-button-wrapper").append(scheduleButton);
     textContainer.siblings(".race-day-button-wrapper").append(circuitInfoButton);
   } else {
     var eventStartDate = raceEventDays[0];

--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -116,7 +116,7 @@ function populateRaceEventContent(block) {
   var raceEventDays = extractRaceEventDates(nextRaceEvent);
   var textContainer = $(block).children(".hero-announcement-text");
 
-  if (raceEventDays.some(eventDate => areSameDate(new Date("05-08-2021"), eventDate))) {
+  if (raceEventDays.some(eventDate => areSameDate(new Date(), eventDate))) {
     textContainer.append($("<h2>").text(`Round ${nextRaceEvent.round} at ${nextRaceEvent.location}`))
     var circuitInfoButton = $("<a>").addClass("hero-announcement-button").attr("href", nextRaceEvent.locationLink).attr("target", "_blank").text("Circuit Info");
     var scheduleUrl = `${window.location.origin}/race/events/${raceEventDays[0].getFullYear()}-round-${nextRaceEvent.round}`;

--- a/layouts/partials/schedule.html
+++ b/layouts/partials/schedule.html
@@ -5,7 +5,7 @@
   {{ $years = $years | append $year }}
 {{ end }}
 
-<div data-debug="{{ $years }}">
+<div>
   {{ range sort $years "value" "desc" }}
     <div>
       <h1>{{ . }} Season</h1>

--- a/themes/wmrra-com-theme/assets/sass/partials/_hero.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_hero.scss
@@ -86,6 +86,10 @@
 
   h2 {
     line-height: 4rem;
+
+    @include media-max($large-screen-breakpoint) {
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Now that we've got an event schedule page, we can welcome a new addition to our dynamic race day buttons. Say HELLO to the ✨ EVENT SCHEDULE BUTTON!! ✨ 

Access your event schedule directly from the homepage on race day! No more questions about "where is the event schedule?" and "what time is my race?"*

<img width="1152" alt="Screen Shot 2021-04-30 at 9 16 20 PM" src="https://user-images.githubusercontent.com/906840/116770590-feb29780-a9f9-11eb-8c8c-17c84245641e.png">

_*disclaimer: you'll still get these questions_