### PR TITLE
Fix dumb news ordering bug

### DIFF
--- a/layouts/partials/home-content-section/latest-news.html
+++ b/layouts/partials/home-content-section/latest-news.html
@@ -1,4 +1,4 @@
-{{ $latestNews := ((where site.RegularPages.ByDate "Section" "news").Reverse | last 4) }}
+{{ $latestNews := ((where site.RegularPages.ByDate "Section" "news").Reverse | first 4) }}
 <div class="home-content-section-wrapper">
   <div class="home-content-section-header">
     <h1>Latest News</h1>


### PR DESCRIPTION
News on the front page was in the wrong order so it was showing the oldest articles, in order of newness. Of course, when there were so few articles, it was impossible to tell the difference.

![sadTrombone](https://media.giphy.com/media/xT5LMFfQQJtiKQ2gCs/giphy.gif)