### PR TITLE
Improve mobile menu layout and styling

### DIFF
--- a/themes/wmrra-com-theme/assets/sass/main.scss
+++ b/themes/wmrra-com-theme/assets/sass/main.scss
@@ -39,12 +39,17 @@ body {
 }
 
 body {
+  height: 100vh;
   font-family: "Fjalla One", sans-serif;
 }
 
 p {
   margin: 0 0 1.5rem;
   line-height: 2.5rem;
+}
+
+#content {
+  min-height: calc(100% - 14.7rem); // allow for header + footer
 }
 
 .content-wrapper {

--- a/themes/wmrra-com-theme/assets/sass/partials/_header.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_header.scss
@@ -45,7 +45,7 @@
   top: 4.7rem;
   right: -1.5rem;
   z-index: 100;
-  width: 35rem;
+  width: 32rem;
   padding: 0 2rem;
   font-size: 2.4rem;
   cursor: pointer;
@@ -113,6 +113,10 @@
         margin-left: 1rem;
       }
     }
+  }
+
+  @include media-min($small-screen-breakpoint) {
+    width: 35rem;
   }
 }
 

--- a/themes/wmrra-com-theme/assets/sass/partials/_header.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_header.scss
@@ -72,9 +72,12 @@
     overflow-y: scroll;
 
     .go_back {
+      position: sticky;
+      top: 0;
       margin: 0 -2rem;
       padding: 1rem;
       border-bottom: 0.1rem solid $light-gray;
+      background-color: $extra-light-gray;
 
       &::before {
         @include pseudo-icon("\f100");

--- a/themes/wmrra-com-theme/assets/sass/partials/_header.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_header.scss
@@ -45,12 +45,8 @@
   top: 4.7rem;
   right: -1.5rem;
   z-index: 100;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
   width: 35rem;
-  min-height: 35rem;
-  padding: 2rem 4rem;
+  padding: 0 2rem;
   font-size: 2.4rem;
   cursor: pointer;
 
@@ -59,16 +55,25 @@
   }
 
   &.main {
+    height: 35rem;
     background-color: $wmmra-dark-red;
     color: $white;
+
+    .mobile-menu-links-wrapper {
+        height: 100%;
+        justify-content: space-around;
+    }
   }
 
-  &.submenu {    
+  &.submenu {
+    height: min-content; 
+    max-height: 50rem;   
     background-color: $extra-light-gray;
+    overflow-y: scroll;
 
     .go_back {
-      margin: 0 -4rem;
-      padding: 0 1rem 1rem;
+      margin: 0 -2rem;
+      padding: 1rem;
       border-bottom: 0.1rem solid $light-gray;
 
       &::before {
@@ -80,6 +85,16 @@
 
     a {
       @include link-overrides($default-text-color);
+    }
+  }
+  
+  .mobile-menu-links-wrapper {
+    display: flex;
+    flex-direction: column;
+    padding: 1rem 0;
+    
+    a {
+      margin: 1rem;
     }
   }
 

--- a/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu-mobile-submenu.html
+++ b/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu-mobile-submenu.html
@@ -3,7 +3,9 @@
 
 <div class="header-menu-mobile-content submenu hidden {{ lower .name }}">
   <div class="go_back">Back</div>
-  {{ range .children }}
-    <a href="{{ .link }}">{{ .name }}</a>
-  {{ end }}
+  <div class="mobile-menu-links-wrapper">
+    {{ range .children }}
+      <a href="{{ .link }}">{{ .name }}</a>
+    {{ end }}
+  </div>
 </div>

--- a/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu-mobile.html
+++ b/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu-mobile.html
@@ -3,11 +3,13 @@
   <i aria-hidden="true" class="menu-icon fas fa-bars" title="Open main menu"></i>
   <i aria-hidden="true" class="menu-close-icon fas fa-times" title="Close menu"></i>
     <div class="header-menu-mobile-content main hidden">
-      {{ range $.Site.Data.menu.menu }}
-        <div class="mobile-menu-link main">
-          {{.name}}
-        </div>
-      {{ end }}
+      <div class="mobile-menu-links-wrapper">
+        {{ range $.Site.Data.menu.menu }}
+          <div class="mobile-menu-link main">
+            {{.name}}
+          </div>
+        {{ end }}
+      </div>
     </div>
 
     {{ range $.Site.Data.menu.menu }}


### PR DESCRIPTION
Fixes https://github.com/wmrra/wmrra-com/issues/5

Mobile menu heights will now be appropriately sized to their content, with a max height to avoid overly-tall menus. Long menus will be scrollable with a sticky back button.

<img width="390" alt="Screen Shot 2021-05-08 at 12 58 59 PM" src="https://user-images.githubusercontent.com/906840/117552405-efd27300-afff-11eb-8e25-8a285a98d5d1.png">
<img width="353" alt="Screen Shot 2021-05-08 at 1 16 51 PM" src="https://user-images.githubusercontent.com/906840/117552412-f2cd6380-afff-11eb-8ac5-211301a16fef.png">



