### PR TITLE
Fix race day bug for events > 2 days

### DIFF
--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -89,7 +89,7 @@ function shouldShowLatestAnnouncement(latestAnnouncementBlock) {
   return daysSinceAnnouncement <= 4;
 }
 
-function isRaceDay(){
+function isRaceDay() {
   return nextRaceEventDays.some(eventDate => areSameDate(new Date(), eventDate));
 }
 
@@ -211,11 +211,25 @@ function extractRaceEventDates(raceEvent) {
   var year = new Date().getFullYear();
   var eventDateParts = raceEvent.date.split(" ");
   var month = getMonthNumber(eventDateParts[0]);
-  var days = eventDateParts[1].split("-");
+  var startAndEndDays = eventDateParts[1].split("-").map(dayString => parseInt(dayString));
+
+  // total days of event: start + end + all days between
+  // if the event is longer than 2 days, we need to add
+  // the days between
+  var startDate = startAndEndDays[0];
+  var endDate = startAndEndDays[1];
+  var eventDays = startAndEndDays;
+  
+  if (endDate - startDate > 1) {
+    // trick for building an " x-to-y range" array:
+    // build an array the length of the range
+    // populate with the index values offset by the range start
+    eventDays = [...Array(endDate - startDate + 1).keys()].map(index => index + startDate);
+  }
 
   // Javascript months are NOT ZERO-INDEXED when you're trying to make a date (╯°□°)╯︵ ┻━┻
   // also, if you don't put the slashes in the date, Safari cries about it
-  return days.map(dayString => new Date(`${month + 1}/${parseInt(dayString)}/${year}`));
+  return eventDays.map(day => new Date(`${month + 1}/${day}/${year}`));
 }
 
 // Returns true if year, month, and day of both of the


### PR DESCRIPTION
Weird bug we saw for the Portland round where Saturday, a race event day featured a negative race day countdown instead of the race day content.

<img width="437" alt="Screenshot 2021-06-12 053758" src="https://user-images.githubusercontent.com/906840/121823742-10739580-cc5c-11eb-820e-bc1488def4fc.png">

This was because the race event was (erroneously?) entered as a 3-day event: June 11 - June 13. The JS for building race event days assumed 2 day events, and thus only used the start and end dates to decide whether or not the current day was "race day." The code has been adapted to handle events longer than 2 days by populating all days between the given start and end. Racing for dayzzzzz.