### PR TITLE
Remove (Chicane) from PIR rounds

### DIFF
--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -8,7 +8,7 @@
 
   - date: June 11-13
     round: 2
-    location: Portland International Raceway (Chicane)
+    location: Portland International Raceway
     locationLink: https://www.portlandraceway.com/
     jointRound: true
     eventSchedule: https://omrra.com/wp-content/uploads/2021/05/OMRRA_June2021_Schedule_V3.pdf
@@ -29,7 +29,7 @@
 
   - date: July 16-18
     round: 5
-    location: Portland International Raceway (Chicane)
+    location: Portland International Raceway
     locationLink: https://www.portlandraceway.com/
     jointRound: true
     eventSchedule: https://omrra.com/wp-content/uploads/2021/07/2021-OMRRA-Race-Schedule-July-Combined-with-Matchup.pdf


### PR DESCRIPTION
Teeny fix - removes `(Chicane)` from the PIR rounds because it breaks a lot of layout stuff unnecessarily.

Before:
<img width="241" alt="Screenshot 2021-07-17 095018" src="https://user-images.githubusercontent.com/906840/126044246-60619073-e9c2-4598-b7d0-f166fd9daff9.png">


After:
<img width="238" alt="Screenshot 2021-07-17 095248" src="https://user-images.githubusercontent.com/906840/126044247-c565b4e8-857b-4c05-b8e3-cd7694960aa0.png">
