### PR TITLE
Fix Link To Hugo Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the repository for the [WMRRA.com](https://wmrra.com) website!
 
 # Running Locally
 
-This project uses a static site generator called [Hugo](gohugo.io).
+This project uses a static site generator called [Hugo](https://gohugo.io).
 
 1) Install [Hugo](https://gohugo.io/getting-started/installing/#quick-install).
    ```bash


### PR DESCRIPTION
The link for the first reference to the Hugo framework was missing a "https" prefix, resulting in GitHub treating it as a relative path, resulting in a 404 error.