### PR TITLE
Alter templates to not require a baseURL to be set

### DIFF
--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -34,9 +34,8 @@ jobs:
               hugo --config config.staging.yml
               # npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-staging
               CHANNEL_ID="staging"
-              npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN  --project wmrra-staging
-              output="$(npx firebase-tools firebase hosting:channel:list --token $FIREBASE_TOKEN  --project wmrra-staging)"
-              echo '::set-output name=STAGING_URL::output'
+              npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN --project wmrra-staging
+              echo "::set-output name=STAGING_URL::$(npx firebase-tools hosting:channel:list --token $FIREBASE_TOKEN --project wmrra-staging)\n"
       - name: "Comment that PR is staged"
         uses: actions/github-script@v3
         with:

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -29,10 +29,14 @@ jobs:
         shell: bash
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        id: firebase-deploy
         run:  |
               hugo --config config.staging.yml
-              npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-staging
-  
+              # npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-staging
+              CHANNEL_ID="staging"
+              npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN  --project wmrra-staging
+              output="$(npx firebase-tools firebase hosting:channel:list --token $FIREBASE_TOKEN  --project wmrra-staging)"
+              echo '::set-output name=STAGING_URL::output'
       - name: "Comment that PR is staged"
         uses: actions/github-script@v3
         with:
@@ -42,7 +46,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged at https://wmrra-staging.web.app'
+              body: 'Staged: ${{ steps.firebase-deploy.outputs.STAGING_URL }}'
+
             })
 
       - name: "Remove stage label"

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -29,13 +29,10 @@ jobs:
         shell: bash
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        id: firebase-deploy
         run:  |
               hugo --config config.staging.yml
-              # npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-staging
-              CHANNEL_ID="staging"
-              npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN --project wmrra-staging
-              echo "::set-output name=STAGING_URL::$(npx firebase-tools hosting:channel:list --token $FIREBASE_TOKEN --project wmrra-staging)\n"
+              npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-staging
+  
       - name: "Comment that PR is staged"
         uses: actions/github-script@v3
         with:
@@ -45,8 +42,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged: ${{ steps.firebase-deploy.outputs.STAGING_URL }}'
-
+              body: 'Staged at https://wmrra-staging.web.app'
             })
 
       - name: "Remove stage label"

--- a/config.staging.yml
+++ b/config.staging.yml
@@ -1,5 +1,4 @@
-#baseURL: https://wmrra.com
-baseURL: https://wmrra-staging.web.app/
+#baseURL: https://wmrra-staging.web.app/
 languageCode: en-us
 title: Washington Motorcycle Road Racing Association
 theme: wmrra-com-theme

--- a/themes/wmrra-com-theme/layouts/partials/header.html
+++ b/themes/wmrra-com-theme/layouts/partials/header.html
@@ -1,8 +1,8 @@
-{{ $logo := "images/WMRRA-logo.jpg" }}
+{{ $logo := "/images/WMRRA-logo.jpg" }}
 <div class="modal-overlay hidden"></div>
 <div class="header">
   <div class="header-logo">
-    <a href="{{ .Site.BaseURL }}"><img class="header-logo" src="{{ $logo | absURL }}"/></a>
+    <a href="{{ "/" | absURL }}"><img class="header-logo" src="{{ $logo | absURL }}"/></a>
   </div>
   <div class="header-menu">
     {{ partial "header-menu/header-menu.html" . }}


### PR DESCRIPTION
while experimenting with staging alterations, I noticed we have a few spots where base url is assumed to be set (optional). This allows the site to work when it isn't set.