### PR TITLE
move to use channels for staging on a single firebase project

### DIFF
--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -33,7 +33,8 @@ jobs:
         run:  |
               hugo --config config.staging.yml
               # npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-prod
-              CHANNEL_ID="${GITHUB_REF#refs/heads/}"
+              PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+              CHANNEL_ID="staging-${PR_NUMBER}"
               npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN --project wmrra-prod
               echo "::set-output name=STAGING_URL::$(npx firebase-tools hosting:channel:list --token $FIREBASE_TOKEN --project wmrra-prod | grep $CHANNEL_ID | sed 's/│/|/g')\n"
       - name: "Comment that PR is staged"

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -33,7 +33,7 @@ jobs:
         run:  |
               hugo --config config.staging.yml
               # npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-prod
-              CHANNEL_ID="staging"
+              CHANNEL_ID="${GITHUB_REF#refs/heads/}"
               npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN --project wmrra-prod
               echo "::set-output name=STAGING_URL::$(npx firebase-tools hosting:channel:list --token $FIREBASE_TOKEN --project wmrra-prod | grep $CHANNEL_ID | sed 's/│/|/g')\n"
       - name: "Comment that PR is staged"

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -45,7 +45,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged:\n\n│ Channel ID │ Last Release Time │ URL │ Expire Time │\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL }}'
+              body: 'Staged:\n\n| Channel ID | Last Release Time | URL | Expire Time |\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL | sed  's/│/|/g'  }}'
             })
 
       - name: "Remove stage label"

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -47,7 +47,6 @@ jobs:
               repo: context.repo.repo,
               body: 'Staged:\n\n| Channel ID | Last Release Time | URL | Expire Time |\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL | sed  "s/│/|/g"  }}'
             })
-
       - name: "Remove stage label"
         uses: actions/github-script@v3
         with:

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -45,8 +45,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged: ${{ steps.firebase-deploy.outputs.STAGING_URL }}'
-
+              body: 'Staged:\n│ Channel ID    │ Last Release Time   │ URL                                                   │ Expire Time         │\n${{ steps.firebase-deploy.outputs.STAGING_URL }}'
             })
 
       - name: "Remove stage label"

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -45,7 +45,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged:\n\n| Channel ID | Last Release Time | URL | Expire Time |\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL | sed  's/│/|/g'  }}'
+              body: 'Staged:\n\n| Channel ID | Last Release Time | URL | Expire Time |\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL | sed  "s/│/|/g"  }}'
             })
 
       - name: "Remove stage label"

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -29,10 +29,13 @@ jobs:
         shell: bash
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        id: firebase-deploy
         run:  |
               hugo --config config.staging.yml
-              npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-staging
-  
+              # npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-prod
+              CHANNEL_ID="staging"
+              npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN --project wmrra-prod
+              echo "::set-output name=STAGING_URL::$(npx firebase-tools hosting:channel:list --token $FIREBASE_TOKEN --project wmrra-prod | grep $CHANNEL_ID)\n"
       - name: "Comment that PR is staged"
         uses: actions/github-script@v3
         with:
@@ -42,7 +45,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged at https://wmrra-staging.web.app'
+              body: 'Staged: ${{ steps.firebase-deploy.outputs.STAGING_URL }}'
+
             })
 
       - name: "Remove stage label"

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -35,7 +35,7 @@ jobs:
               # npx firebase-tools deploy --token $FIREBASE_TOKEN  --project wmrra-prod
               CHANNEL_ID="staging"
               npx firebase-tools hosting:channel:deploy $CHANNEL_ID --token $FIREBASE_TOKEN --project wmrra-prod
-              echo "::set-output name=STAGING_URL::$(npx firebase-tools hosting:channel:list --token $FIREBASE_TOKEN --project wmrra-prod | grep $CHANNEL_ID)\n"
+              echo "::set-output name=STAGING_URL::$(npx firebase-tools hosting:channel:list --token $FIREBASE_TOKEN --project wmrra-prod | grep $CHANNEL_ID | sed 's/│/|/g')\n"
       - name: "Comment that PR is staged"
         uses: actions/github-script@v3
         with:
@@ -45,7 +45,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged:\n\n| Channel ID | Last Release Time | URL | Expire Time |\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL | sed  "s/│/|/g"  }}'
+              body: 'Staged:\n\n| Channel ID | Last Release Time | URL | Expire Time |\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL }}'
             })
       - name: "Remove stage label"
         uses: actions/github-script@v3

--- a/.github/workflows/firebase_staging_deploy.yml
+++ b/.github/workflows/firebase_staging_deploy.yml
@@ -45,7 +45,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Staged:\n│ Channel ID    │ Last Release Time   │ URL                                                   │ Expire Time         │\n${{ steps.firebase-deploy.outputs.STAGING_URL }}'
+              body: 'Staged:\n\n│ Channel ID │ Last Release Time │ URL │ Expire Time │\n|----|----|----|----|\n${{ steps.firebase-deploy.outputs.STAGING_URL }}'
             })
 
       - name: "Remove stage label"


### PR DESCRIPTION
Firebase Hosting has added channels. This could be used in place of a separate staging project. It is in beta though so the commands could regress.