### PR TITLE
Dynamically populate homepage schedule

### DIFF
--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,0 +1,82 @@
+const SCHEDULE_TABLE_CELLS = [
+  { className: "round", key: "round" },
+  { className: "date", key: "date" },
+  { className: "location", key: "location" },
+  { className: "day-schedule", key: "eventSchedule" },
+  { className: "joint-round", key: "jointRound" },
+];
+
+function displayCurrentSchedule() {
+  const scheduleSection = $(".home-content-section.homepage-schedule");
+  const scheduleData = scheduleSection?.data("schedule") ?? {};
+  const [scheduleToDisplay, scheduleYear] = pickScheduleToDisplay(scheduleData);
+
+  // probably means there's no schedule data
+  // just drop the schedule section off the page
+  if (scheduleToDisplay == null) {
+    if (scheduleSection.length > 0) {
+      scheduleSection.remove();
+    }
+    return;
+  }
+
+  // remove the data attr to hide our sins
+  scheduleSection.removeAttr("data-schedule");
+
+  // add the year in the header
+  scheduleSection.find(".home-content-section-header").find("#current-year").text(scheduleYear);
+
+  // add the event rows to the schedule table
+  const scheduleTable = scheduleSection.find(".schedule-table");
+  const jointRoundIcon = $("<i>").addClass("fas fa-check-circle joint-round-icon").attr({"aria-hidden": true, "title": "Joint round with OMRRA" });
+  const jointRoundText = $("<span>").addClass("joint-round-text").text("Joint round with OMRRA");
+  
+  for (const raceEventData of scheduleToDisplay) {
+    const scheduleRow = $("<div>").addClass("schedule-table-row");
+    for (const cellData of SCHEDULE_TABLE_CELLS) {
+      const { className, key } = cellData;
+      const cellElement = $("<div>").addClass(`schedule-table-cell ${className}`);
+      const cellContents = raceEventData[key];
+      if (cellContents) {
+        switch(key) {
+          case "round":
+            cellElement.text(`Round ${cellContents}`);
+            break;
+          case "eventSchedule":
+            const scheduleLink = $("<a>").attr({ href: cellContents, target: "_blank"});
+            cellElement.append(scheduleLink);
+            break;
+          case "jointRound":
+            cellElement.append(jointRoundIcon.clone());
+            cellElement.append(jointRoundText.clone());
+            break;
+          default:
+            cellElement.text(cellContents);
+            break;
+        }
+      }
+      scheduleRow.append(cellElement);     
+    }
+    scheduleTable.append(scheduleRow);
+  }
+
+  scheduleSection.removeClass("loading");
+}
+
+function pickScheduleToDisplay(scheduleData) {
+  const currentYear = new Date().getFullYear();
+  const [previousYear, nextYear] = [currentYear -1, currentYear + 1];
+  if (scheduleData[nextYear]){
+    return [scheduleData[nextYear], nextYear];
+  } else if (scheduleData[currentYear]) {
+    return [scheduleData[currentYear], currentYear];
+  } else {
+    return [scheduleData[previousYear], previousYear];
+  }
+}
+
+$(document).ready(function() {
+  if ($(".home-content-section.homepage-schedule").length > 0) {
+    displayCurrentSchedule();
+  }
+});

--- a/assets/sass/partials/_homepage.scss
+++ b/assets/sass/partials/_homepage.scss
@@ -102,8 +102,30 @@
   }
 
   &.homepage-schedule {
+    min-height: 40rem;
     background-color: $wmrra-light-gray;
     color: $wmmra-dark-red;
+    
+    &.loading {
+      .schedule-loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        grid-row: span 2;
+        font-size: 5rem;
+      }
+
+      .home-content-section-header,
+      .homepage-schedule-wrapper {
+        display: none;
+      }
+    }
+
+    &:not(.loading) {
+      .schedule-loading {
+        display: none;
+      }
+    }
   }
 }
 

--- a/layouts/partials/custom-scripts.html
+++ b/layouts/partials/custom-scripts.html
@@ -1,7 +1,9 @@
+{{ $homeScript := resources.Get "js/home.js" | minify }}
 {{ $heroScript := resources.Get "js/hero.js" | minify }}
 {{ $supporterScript := resources.Get "js/supporter-levels.js" | minify }}
 {{ $racersScript := resources.Get "js/racers.js" | minify }}
 
+<script src="{{ $homeScript.Permalink }}"></script>
 <script src="{{ $heroScript.Permalink }}"></script>
 <script src="{{ $supporterScript.Permalink }}"></script>
 <script src="{{ $racersScript.Permalink }}"></script>

--- a/layouts/partials/home-content-section/homepage-schedule.html
+++ b/layouts/partials/home-content-section/homepage-schedule.html
@@ -1,10 +1,28 @@
-
+{{/*
+   As a monument to my sins, this whole thing gets populated via Javascript
+   so we can automatically update it with the current year's schedule
+*/}}
 <div class="home-content-section-wrapper homepage-schedule">
+  <div class="schedule-loading">
+    <i aria-hidden="true" class="fa fa-spinner fa-pulse" title="Schedule loading"></i>
+  </div>
+
   <div class="home-content-section-header">
-    <h1>{{.year }} Race Schedule</h1>
+    <h1><span id="current-year"></span> Race Schedule</h1>
   </div>
 
   <div class="homepage-schedule-wrapper">
-    {{ partial "schedule-table" (dict "scheduleData" .scheduleData) }}  
+    <div class="schedule-table">
+      <div class="schedule-table-row table-header">
+        <div class="schedule-table-cell round">
+          {{/* This space left intentionally blank */}}
+        </div>
+        <div class="schedule-table-cell date">Date</div>
+        <div class="schedule-table-cell location">Location</div>
+        <div class="schedule-table-cell day-schedule">Schedule</div>
+    
+        <div class="schedule-table-cell joint-round">OMRRA</div>
+      </div>
+    </div>
   </div>
 </div>

--- a/layouts/partials/home-content.html
+++ b/layouts/partials/home-content.html
@@ -1,5 +1,4 @@
-{{ $whatYearIsIt := string time.Now.Year }}
-{{ $currentSchedule := index .Site.Data.schedule $whatYearIsIt }}
+{{ $scheduleJson := jsonify .Site.Data.schedule }}
 
 <div class="home-content">
   <div class="home-content-section we-are-wmrra">
@@ -10,9 +9,9 @@
     {{ partial "home-content-section/latest-news" . }}
   </div>
 
-  {{ with $currentSchedule }}
-    <div class="home-content-section homepage-schedule">
-      {{ partial "home-content-section/homepage-schedule" (dict "scheduleData" $currentSchedule "year" $whatYearIsIt) }}
+  {{ with $scheduleJson }}
+    <div data-schedule="{{ $scheduleJson }}" class="home-content-section homepage-schedule loading">
+      {{ partial "home-content-section/homepage-schedule" }}
     </div>
   {{ end }}
 


### PR DESCRIPTION
In my never ending quest to make this static website fully dynamic and yet still static, this adds the functionality required to ensure the homepage schedule updates dynamically to the most current schedule (next year's or this year's, whichever is available).

_"But Anna," you say, "couldn't you just do a deploy to update the year in the generated code?"_
**NO.** Because I won't be running this forever and someone will forget to do the deploy, or not realize that's what needs to happen, or what have you, and there will be an old schedule moldering away on the homepage and it will look unprofessional.

There is a potential breakdown here if the next year's schedule is released while the current year's is still ongoing, but that never happens (right?). It can be fixed, but it requires some extra complexity that I don't want to add unless it becomes absolutely necessary.  This also breaks down if we ever change the schedule data format, but that's another bridge we can cross if we ever get there.

![dynamicHomepageSchedule](https://user-images.githubusercontent.com/906840/149653164-58ddddc7-d0d5-4e1a-808b-6d2a7379e00e.gif)

Note that the loading state isn't likely to show (this all happens pretty fast), but it's there just in case (I artificially slowed it down for the demo gif).