### PR TITLE
Add 2023 to schedule

### DIFF
--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -1,3 +1,40 @@
+"2023":
+  - date: May 5-7
+    round: 1
+    location: Portland International Raceway
+    locationLink: https://www.portlandraceway.com/
+    jointRound: true
+ 
+  - date: June 9-11
+    round: 2
+    location: Portland International Raceway
+    locationLink: https://www.portlandraceway.com/
+    jointRound: true
+
+  - date: June 16-18
+    round: 3
+    location: The Ridge Motorsports Park
+    locationLink: https://www.ridgemotorsportspark.com/
+    jointRound: false
+
+  - date: July 14-16
+    round: 4
+    location: Portland International Raceway
+    locationLink: https://www.portlandraceway.com/
+    jointRound: true
+
+  - date: September 1-4
+    round: 5
+    location: Pacific Raceways
+    locationLink: https://pacificraceways.com/
+    jointRound: false
+
+  - date: September 15-17
+    round: 6
+    location: The Ridge Motorsports Park
+    locationLink: https://www.ridgemotorsportspark.com/
+    jointRound: true
+
 "2022":
   - date: May 6-8
     round: 1


### PR DESCRIPTION
Added the 2023 rounds to the schedule data file. The April 22 official test day at PIR has been omitted since we can't assign it a round number and the current system expects a round number.