### PR TITLE
Fix schedule spelling

### DIFF
--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -34,7 +34,7 @@
     jointRound: true
     -- eventSchedule: /pdfs/rulebook/2023R5_Schedule.pdf
 
-  - date: Sepetmber 6-8
+  - date: September 6-8
     round: 6
     location: Portland International Raceway
     locationLink: https://www.portlandraceway.com/


### PR DESCRIPTION
Fixing the spelling error in the schedule solves the problem with it not rendering the current scheduled race.

<img width="927" alt="Screenshot 2024-09-16 195525" src="https://github.com/user-attachments/assets/e6339955-eada-48e5-9d2d-a1e4a5ca3187">
