### PR TITLE
Add WMRRA shop link + allow header menu to have top-level links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ The racer numbers are defined at [csv/race-numbers.csv](csv/race-numbers.csv)
 ## Updating the Menu
 The menu is defined at [data/menu.yml](data/menu.yml)
 
-Menus are under top menu names and include a name and a link. For example:
+Menu items can either be a top-level link or label with links in a submenu.
+
+Top-level links are defined this way:
+```
+- name: Volunteer
+  link: /volunteer
+```
+
+Labels with submenus are defined this way:
 ```
   - name: Resources
     children: 

--- a/data/menu.yml
+++ b/data/menu.yml
@@ -19,14 +19,11 @@ menu:
         link: /resources/documents-and-forms
 
   - name: Spectate
-    children: 
-      - name: Watch a WMRRA Race
-        link: /spectate
+    link: /spectate
+
 
   - name: Volunteer
-    children: 
-      - name: Volunteer with WMRRA
-        link: /volunteer
+    link: /volunteer
 
   - name: Sponsor
     children: 
@@ -68,3 +65,6 @@ menu:
       #   link: /rules-proposals
       - name: Report a Website Issue
         link: https://github.com/wmrra/wmrra-com/issues/new/choose
+
+  - name: WMRRA Shop
+    link: https://wmrra.boldstores.com

--- a/themes/wmrra-com-theme/assets/sass/main.scss
+++ b/themes/wmrra-com-theme/assets/sass/main.scss
@@ -12,10 +12,10 @@ $extra-light-gray: #fcfcfc;
 $default-box-shadow: 0 0.8rem 0.8rem -0.5rem rgba(0, 0, 0, 0.3);
 
 // approx px as em values - https://stackoverflow.com/a/43131958
-$small-screen-breakpoint: 23rem; // 360px
+$small-screen-breakpoint: 23em; // 360px
 $medium-screen-breakpoint: 30em; // 480px
-$mobile-breakpoint: 48em; // 768px
-$large-screen-breakpoint: 64rem; // 1024px
+$mobile-breakpoint: 52em; // 832px
+$large-screen-breakpoint: 64em; // 1024px
 $xlarge-screen-breakpoint: 81em; // 1300px
 $xxlarge-screen-breakpoint: 100em; // 1600px
 $xxxlarge-screen-breakpoint: 120em; // big

--- a/themes/wmrra-com-theme/assets/sass/partials/_header.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_header.scss
@@ -2,8 +2,8 @@
 
 .header {
   display: grid;
-  grid-template-columns: 0.3fr 1fr;
-  grid-gap: 3rem;
+  grid-template-columns: 0.25fr 1fr;
+  grid-gap: 1rem;
   align-items: center;
   padding: 0 1.5rem;
   height: 6.5rem;
@@ -129,12 +129,17 @@
   align-items:  center;
 }
 
+a {
+  &.header-menu-item {
+    @include link-overrides($default-text-color); 
+  }
+}
+
 .header-menu-item {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 6.5rem;
-  width: 9.5rem;
   cursor: pointer;
 
   &:hover {

--- a/themes/wmrra-com-theme/assets/sass/partials/_header.scss
+++ b/themes/wmrra-com-theme/assets/sass/partials/_header.scss
@@ -97,7 +97,17 @@
     padding: 1rem 0;
     
     a {
-      margin: 1rem;
+      &:not(.main) {
+        margin: 1rem;
+      }
+    }
+  }
+
+  a {
+    &.mobile-menu-link {
+      &.main {
+        @include link-overrides($white);
+      }
     }
   }
 

--- a/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu-mobile.html
+++ b/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu-mobile.html
@@ -1,3 +1,18 @@
+<!--
+  We have 2 different types of header menu entries
+
+  Option 1: Menu item is a direct link (no children)
+  - name: top-level name
+    link: direct page link or URL
+
+  Option 2: Menu item has several children  
+  - name: top-level name
+    children: 
+      - name: link-1
+        link: direct page link or URL
+      - name: link-2
+        link: direct page link or URL
+-->
 <div class="header-menu-mobile-overlay hidden"></div>
 <div class="header-menu-mobile">
   <i aria-hidden="true" class="menu-icon fas fa-bars" title="Open main menu"></i>
@@ -5,14 +20,22 @@
     <div class="header-menu-mobile-content main hidden">
       <div class="mobile-menu-links-wrapper">
         {{ range $.Site.Data.menu.menu }}
-          <div class="mobile-menu-link main">
-            {{.name}}
-          </div>
+          {{ if .link }}
+            <a href="{{.link}}" class="mobile-menu-link main">
+              {{ .name }}
+            </a>
+          {{ else }}
+            <div class="mobile-menu-link main">
+              {{.name}}
+            </div>
+          {{ end }}
         {{ end }}
       </div>
     </div>
 
     {{ range $.Site.Data.menu.menu }}
-      {{ partial "header-menu/header-menu-mobile-submenu" . }}
+      {{ if .children }}
+        {{ partial "header-menu/header-menu-mobile-submenu" . }}
+      {{ end }}  
     {{ end }}
 </div>

--- a/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu.html
+++ b/themes/wmrra-com-theme/layouts/partials/header-menu/header-menu.html
@@ -1,37 +1,50 @@
 
 <!--
-- name: top-level name
-  link:
-  children: 
-    - name: link-1
-      link: 
-    - name: link-2
-      link:
+  We have 2 different types of header menu entries
+
+  Option 1: Menu item is a direct link (no children)
+  - name: top-level name
+    link: direct page link or URL
+
+  Option 2: Menu item has several children  
+  - name: top-level name
+    children: 
+      - name: link-1
+        link: direct page link or URL
+      - name: link-2
+        link: direct page link or URL
 -->
+
 {{ range $.Site.Data.menu.menu }}
-
-<!--
-  Submenus are nested in the label so they can
-  all be absolutely positioned w/ respect to their
-  label. This allows the menu buttons to be positioned
-  via flex while keeping the submenus consistently
-  positioned under them using the same position values.
-  tl;dr - nesting the subemenus inside the labels is a
-  a little weird, but don't un-nest it, or the styling breaks.
--->
-<div class="header-menu-item">
-  <div class="header-menu-item-label">
-    {{ .name }}
-    <div class="header-menu-item-submenu">
-      {{ range .children }}
-        <div class="submenu-item-wrapper">
-          <a href="{{.link}}">{{ .name }}</a>
+  {{ if .link }}
+    <a href="{{.link}}" class="header-menu-item">
+      <div class="header-menu-item-label">
+        {{ .name }}
+      </div>
+    </a>
+  {{ else }}
+    <!--
+      Submenus are nested in the label so they can
+      all be absolutely positioned w/ respect to their
+      label. This allows the menu buttons to be positioned
+      via flex while keeping the submenus consistently
+      positioned under them using the same position values.
+      tl;dr - nesting the subemenus inside the labels is a
+      a little weird, but don't un-nest it, or the styling breaks.
+    -->
+    <div class="header-menu-item">
+      <div class="header-menu-item-label">
+        {{ .name }}
+        <div class="header-menu-item-submenu">
+          {{ range .children }}
+            <div class="submenu-item-wrapper">
+              <a href="{{.link}}">{{ .name }}</a>
+            </div>
+          {{ end }}
         </div>
-      {{ end }}
+      </div>
     </div>
-  </div>
-</div>
-
+  {{ end }}
 {{ end }}
 
 {{ with $.Site.Data.menu.ctaButton }}


### PR DESCRIPTION
1. Add the WMRRA shop link to the header
2. Allow the header to have "top-level" links that don't trigger sub-menus (such as the shop link)
3. Update some header styles and mobile breakpoints to accommodate the shop link in the header
4. Update the README for adding menu items

The second item fixes #173. A 2++ year old issue. How about that, eh?

**Wide screens**

https://github.com/user-attachments/assets/cd4ed5a8-9852-4ea4-8a99-501b6bc8728d

**Small/mobile screens**

https://github.com/user-attachments/assets/8f2d4509-c680-4dae-be93-a6d114e72051

